### PR TITLE
add missing conformance test fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+0.2.2
+-----
+
+Synchronized the list of statement fixtures with the test cases of the
+`php-xapi/test-fixtures` package.
+
 0.2.1
 -----
 

--- a/data/Statement/typical_statement.json
+++ b/data/Statement/typical_statement.json
@@ -1,0 +1,18 @@
+{
+  "id": "12345678-1234-5678-8234-567812345678",
+  "actor": {
+    "mbox": "mailto:conformancetest@tincanapi.com",
+    "objectType": "Agent"
+  },
+  "verb": {
+    "id": "http://tincanapi.com/conformancetest/verbid",
+    "display": {
+      "en-US": "test"
+    }
+  },
+  "object": {
+    "id": "http://tincanapi.com/conformancetest/activityid",
+    "objectType": "Activity"
+  },
+  "timestamp": "2014-07-23T12:34:02-05:00"
+}

--- a/data/Statement/voiding_statement.json
+++ b/data/Statement/voiding_statement.json
@@ -1,0 +1,17 @@
+{
+  "id": "12345678-1234-5678-8234-567812345678",
+  "actor": {
+    "mbox": "mailto:conformancetest@tincanapi.com",
+    "objectType": "Agent"
+  },
+  "verb": {
+    "id": "http://adlnet.gov/expapi/verbs/voided",
+    "display": {
+      "en-US": "voided"
+    }
+  },
+  "object": {
+    "id": "e05aa883-acaf-40ad-bf54-02c8ce485fb0",
+    "objectType": "StatementRef"
+  }
+}

--- a/data/Statement/with_group_actor.json
+++ b/data/Statement/with_group_actor.json
@@ -1,0 +1,17 @@
+{
+  "id": "12345678-1234-5678-8234-567812345678",
+  "actor": {
+    "objectType": "Group",
+    "mbox": "mailto:conformancetest-group@tincanapi.com"
+  },
+  "verb": {
+    "id": "http://tincanapi.com/conformancetest/verbid",
+    "display": {
+      "en-US": "test"
+    }
+  },
+  "object": {
+    "id": "http://tincanapi.com/conformancetest/activityid",
+    "objectType": "Activity"
+  }
+}

--- a/data/Statement/with_group_actor_without_members.json
+++ b/data/Statement/with_group_actor_without_members.json
@@ -1,0 +1,17 @@
+{
+  "id": "12345678-1234-5678-8234-567812345678",
+  "actor": {
+    "objectType": "Group",
+    "mbox": "mailto:conformancetest-group@tincanapi.com"
+  },
+  "verb": {
+    "id": "http://tincanapi.com/conformancetest/verbid",
+    "display": {
+      "en-US": "test"
+    }
+  },
+  "object": {
+    "id": "http://tincanapi.com/conformancetest/activityid",
+    "objectType": "Activity"
+  }
+}

--- a/src/StatementJsonFixtures.php
+++ b/src/StatementJsonFixtures.php
@@ -30,6 +30,36 @@ class StatementJsonFixtures extends JsonFixtures
         return static::load('minimal_statement');
     }
 
+    public static function getTypicalStatement()
+    {
+        return static::load('typical_statement');
+    }
+
+    public static function getVoidingStatement()
+    {
+        return static::load('voiding_statement');
+    }
+
+    /**
+     * Loads a statement with a group as an actor.
+     *
+     * @return string
+     */
+    public static function getStatementWithGroupActor()
+    {
+        return static::load('with_group_actor');
+    }
+
+    /**
+     * Loads a statement with a group that has no members as an actor.
+     *
+     * @return string
+     */
+    public static function getStatementWithGroupActorWithoutMembers()
+    {
+        return static::load('with_group_actor_without_members');
+    }
+
     /**
      * Loads a statement including a reference to another statement.
      *


### PR DESCRIPTION
These four test case were present in the `php-xapi/test-fixtures`
package, but didn't have the respective JSON format.
