### PR TITLE
remove invalid non IRI extensions fixture

### DIFF
--- a/data/Extensions/invalid_non_iri.json
+++ b/data/Extensions/invalid_non_iri.json
@@ -1,3 +1,0 @@
-{
-  "test": "key not an IRI"
-}

--- a/src/ExtensionsJsonFixtures.php
+++ b/src/ExtensionsJsonFixtures.php
@@ -45,9 +45,4 @@ class ExtensionsJsonFixtures extends JsonFixtures
     {
         return self::load('multiple_pairs');
     }
-
-    public static function getInvalidNonIriExtensions()
-    {
-        return self::load('invalid_non_iri');
-    }
 }


### PR DESCRIPTION
With the introduction of the IRI class, it is no longer possible to
create extensions without a valid IRI.
